### PR TITLE
Improve active trip counting efficiency

### DIFF
--- a/gtfstk/helpers.py
+++ b/gtfstk/helpers.py
@@ -257,6 +257,32 @@ def count_active_trips(trip_times, time):
     t = trip_times
     return t[(t['start_time'] <= time) & (t['end_time'] > time)].shape[0]
 
+
+def get_active_trips_df(trip_times):
+    """
+    Count the number of trips in ``trip_times`` that are active
+    at any given time.
+
+    Parameters
+    ----------
+    trip_times : DataFrame
+        Contains columns
+
+        - start_time: start time of the trip in seconds past midnight
+        - end_time: end time of the trip in seconds past midnight
+
+    Returns
+    -------
+    Series
+        index is times from midnight when trips start and end, values are number of active trips for that time
+
+    """
+    active_trips = pd.concat([pd.Series(1, trip_times.start_time),  # departed add 1
+                              pd.Series(-1, trip_times.end_time)    # arrived subtract 1
+                              ]).groupby(level=0, sort=True).sum().cumsum().ffill()
+    return active_trips
+
+
 def combine_time_series(time_series_dict, kind, *, split_directions=False):
     """
     Combine the many time series DataFrames in the given dictionary

--- a/gtfstk/miscellany.py
+++ b/gtfstk/miscellany.py
@@ -376,8 +376,8 @@ def compute_feed_stats(feed, trip_stats, dates):
               stats['service_distance']/stats['service_duration']
 
             # Compute peak stats, which is the slowest part
-            times = np.unique(f[['start_time', 'end_time']].values)
-            counts = [hp.count_active_trips(f, t) for t in times]
+            active_trips = hp.get_active_trips_df(f[['start_time', 'end_time']])
+            times, counts = active_trips.index.values, active_trips.values
             start, end = hp.get_peak_indices(times, counts)
             stats['peak_num_trips'] = counts[start]
             stats['peak_start_time'] = times[start]

--- a/gtfstk/routes.py
+++ b/gtfstk/routes.py
@@ -131,8 +131,8 @@ def compute_route_stats_base(trip_stats_subset,
             d['mean_headway'] = np.nan
 
         # Compute peak num trips
-        times = np.unique(group[['start_time', 'end_time']].values)
-        counts = [hp.count_active_trips(group, t) for t in times]
+        active_trips = hp.get_active_trips_df(group[['start_time', 'end_time']])
+        times, counts = active_trips.index.values, active_trips.values
         start, end = hp.get_peak_indices(times, counts)
         d['peak_num_trips'] = counts[start]
         d['peak_start_time'] = times[start]
@@ -173,8 +173,8 @@ def compute_route_stats_base(trip_stats_subset,
             d['mean_headway'] = np.nan
 
         # Compute peak num trips
-        times = np.unique(group[['start_time', 'end_time']].values)
-        counts = [hp.count_active_trips(group, t) for t in times]
+        active_trips = hp.get_active_trips_df(group[['start_time', 'end_time']])
+        times, counts = active_trips.index.values, active_trips.values
         start, end = hp.get_peak_indices(times, counts)
         d['peak_num_trips'] = counts[start]
         d['peak_start_time'] = times[start]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,6 +3,7 @@ import pytest
 import pandas as pd
 import numpy as np
 from numpy.testing import assert_array_equal
+from pandas.testing import assert_series_equal
 import shapely.geometry as sg
 
 from .context import gtfstk, slow
@@ -86,3 +87,15 @@ def test_is_not_null():
 
     f = pd.DataFrame([[1, np.nan], [2, 2]], columns=['bar', c])
     assert is_not_null(f, c)
+
+def test_get_active_trips_df():
+    f = pd.DataFrame([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], columns=['start_time', 'end_time'])
+    expect = pd.Series(index=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], data=[1, 2, 3, 4, 5, 4, 3, 2, 1, 0])
+    get = get_active_trips_df(f)
+    assert_series_equal(get, expect)
+
+    f = pd.DataFrame([[1, 2, 3, 4, 5], [2, 4, 6, 8, 10]], columns=['start_time', 'end_time'])
+    expect = pd.Series(index=[1, 2, 3, 4, 5, 6, 8, 10], data=[1, 1, 2, 2, 3, 2, 1, 0])
+    get = get_active_trips_df(f)
+    assert_series_equal(get, expect)
+

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -88,13 +88,14 @@ def test_is_not_null():
     f = pd.DataFrame([[1, np.nan], [2, 2]], columns=['bar', c])
     assert is_not_null(f, c)
 
+
 def test_get_active_trips_df():
-    f = pd.DataFrame([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], columns=['start_time', 'end_time'])
+    f = pd.DataFrame({'start_time': [1, 2, 3, 4, 5], 'end_time': [6, 7, 8, 9, 10]})
     expect = pd.Series(index=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], data=[1, 2, 3, 4, 5, 4, 3, 2, 1, 0])
     get = get_active_trips_df(f)
     assert_series_equal(get, expect)
 
-    f = pd.DataFrame([[1, 2, 3, 4, 5], [2, 4, 6, 8, 10]], columns=['start_time', 'end_time'])
+    f = pd.DataFrame({'start_time': [1, 2, 3, 4, 5], 'end_time': [2, 4, 6, 8, 10]})
     expect = pd.Series(index=[1, 2, 3, 4, 5, 6, 8, 10], data=[1, 1, 2, 2, 3, 2, 1, 0])
     get = get_active_trips_df(f)
     assert_series_equal(get, expect)


### PR DESCRIPTION
Changed implementation for a significant efficiency improvement (compute_route_stats for a single date went from 4-5 minutes to 40-50 seconds on the feed I'm working on).  

Using this in a new mashup I'm working on between [partridge](https://github.com/remix/partridge/) and gtfstk for more efficient daily stats - code for that one is [here](https://github.com/hasadna/open-bus/blob/gtfs_stats/gtfs_utils/gtfs_utils/gtfs_stats.py)