### PR TITLE
fix: don't calculate geometry for stops w/o lat/lon

### DIFF
--- a/gtfstk/stops.py
+++ b/gtfstk/stops.py
@@ -369,6 +369,8 @@ def build_geometry_by_stop(
     if stop_ids is not None:
         stops = stops[stops["stop_id"].isin(stop_ids)]
 
+    stops = stops[stops.stop_lat.notna() & stops.stop_lon.notna()]
+
     if use_utm:
         for stop, group in stops.groupby("stop_id"):
             lat, lon = group[["stop_lat", "stop_lon"]].values[0]


### PR DESCRIPTION
Now that #11 landed, it's possible for stops.txt to include stops without a lat/lon. This filters those stops out when calculating geometry, which does require a lat/lon.