### PR TITLE
Validators shapes/stop_times indices bug

### DIFF
--- a/gtfstk/validators.py
+++ b/gtfstk/validators.py
@@ -1276,6 +1276,7 @@ def check_stop_times(
 
     indices = []
     prev_tid = None
+    prev_index = None
     prev_atime = 1
     prev_dtime = 1
     for i, tid, atime, dtime, tp in f[
@@ -1284,7 +1285,7 @@ def check_stop_times(
         if tid != prev_tid:
             # Check last stop of previous trip
             if pd.isna(prev_atime) or pd.isna(prev_dtime):
-                indices.append(i - 1)
+                indices.append(prev_index)
             # Check first stop of current trip
             if pd.isna(atime) or pd.isna(dtime):
                 indices.append(i)
@@ -1293,8 +1294,12 @@ def check_stop_times(
             indices.append(i)
 
         prev_tid = tid
+        prev_index = i
         prev_atime = atime
         prev_dtime = dtime
+
+    if pd.isna(prev_atime) or pd.isna(prev_dtime):
+        indices.append(prev_index)
 
     if indices:
         problems.append(

--- a/gtfstk/validators.py
+++ b/gtfstk/validators.py
@@ -1041,6 +1041,7 @@ def check_shapes(
     problems = check_for_required_columns(problems, table, f)
     if problems:
         return format_problems(problems, as_df=as_df)
+    f.sort_values(["shape_id", "shape_pt_sequence"], inplace=True)
 
     if include_warnings:
         problems = check_for_invalid_columns(problems, table, f)
@@ -1071,13 +1072,15 @@ def check_shapes(
         g = f.dropna(subset=["shape_dist_traveled"])
         indices = []
         prev_sid = None
+        prev_index = None
         prev_dist = -1
         cols = ["shape_id", "shape_dist_traveled"]
         for i, sid, dist in g[cols].itertuples():
             if sid == prev_sid and dist < prev_dist:
-                indices.append(i)
+                indices.append(prev_index)
 
             prev_sid = sid
+            prev_index = i
             prev_dist = dist
 
         if indices:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -439,14 +439,21 @@ def test_check_shapes():
         assert check_shapes(feed1)
 
     feed1 = feed.copy()
-    feed.shapes["shape_pt_sequence"].iat[1] = feed.shapes[
+    feed1.shapes["shape_pt_sequence"].iat[1] = feed1.shapes[
         "shape_pt_sequence"
     ].iat[0]
-    assert check_shapes(feed)
+    assert check_shapes(feed1)
 
     feed1 = feed.copy()
     feed1.shapes["shape_dist_traveled"].iat[1] = 0
     assert check_shapes(feed1)
+
+    feed1 = feed.copy()
+    t1 = feed1.shapes.iloc[0].copy()
+    t2 = feed1.shapes.iloc[1].copy()
+    feed1.shapes.iloc[0] = t2
+    feed1.shapes.iloc[1] = t1
+    assert not check_shapes(feed1)
 
 
 def test_check_stops():
@@ -596,6 +603,8 @@ def test_check_stop_times():
 
     # Return the correct index of the missing time
     feed = sample.copy()
+    # Index 2 is the first stop of the second trip
+    # Index 2 is the last stop of the second trip
     feed.stop_times["arrival_time"].iat[6] = np.nan
     t1, t2 = feed.stop_times.iloc[2].copy(), feed.stop_times.iloc[6].copy()
     feed.stop_times.iloc[2], feed.stop_times.iloc[6] = t2, t1
@@ -603,7 +612,7 @@ def test_check_stop_times():
 
     # Check for last stop of last trip
     # Trips are ordered by trip_id so the STBA trip_id from the sample feed
-    # is last
+    # is last and its last stop (index 1) is the last row
     feed = sample.copy()
     feed.stop_times["arrival_time"].iat[1] = np.nan
     assert check_stop_times(feed)
@@ -698,3 +707,6 @@ def test_check_trips():
 
 def test_validate():
     assert not validate(sample, as_df=False, include_warnings=False)
+
+if __name__ == "__main__":
+    test_check_shapes()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -707,6 +707,3 @@ def test_check_trips():
 
 def test_validate():
     assert not validate(sample, as_df=False, include_warnings=False)
-
-if __name__ == "__main__":
-    test_check_shapes()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -594,6 +594,20 @@ def test_check_stop_times():
     assert not check_stop_times(feed)
     assert check_stop_times(feed, include_warnings=True)
 
+    # Return the correct index of the missing time
+    feed = sample.copy()
+    feed.stop_times["arrival_time"].iat[6] = np.nan
+    t1, t2 = feed.stop_times.iloc[2].copy(), feed.stop_times.iloc[6].copy()
+    feed.stop_times.iloc[2], feed.stop_times.iloc[6] = t2, t1
+    assert check_stop_times(feed)[0][3][0] == 2
+
+    # Check for last stop of last trip
+    # Trips are ordered by trip_id so the STBA trip_id from the sample feed
+    # is last
+    feed = sample.copy()
+    feed.stop_times["arrival_time"].iat[1] = np.nan
+    assert check_stop_times(feed)
+
 
 def test_check_transfers():
     assert not check_transfers(sample)


### PR DESCRIPTION
Fixed 2 bugs where if the dataframe was not ordered by default, then some of the returned indices were wrong. In addition, I sorted the dataframe in check_shapes.