### PR TITLE
Check agency exists in validators.check_routes

### DIFF
--- a/gtfstk/validators.py
+++ b/gtfstk/validators.py
@@ -956,7 +956,16 @@ def check_routes(
 
     # Check agency_id
     if "agency_id" in f:
-        if "agency_id" not in feed.agency.columns:
+        if feed.agency is None:
+            problems.append(
+                [
+                    "error",
+                    "agency_id column present in routes agency table missing",
+                    table,
+                    [],
+                ]
+            )
+        elif "agency_id" not in feed.agency.columns:
             problems.append(
                 [
                     "error",

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -400,6 +400,10 @@ def test_check_routes():
     assert not check_routes(feed)
     assert check_routes(feed, include_warnings=True)
 
+    feed = sample.copy()
+    feed.agency = None
+    assert check_routes(feed)
+
 
 def test_check_shapes():
     assert not check_shapes(sample)


### PR DESCRIPTION
Added an extra condition which checks if feed.agency exists in order to avoid the invalid key error from feed.agency.columns