### PR TITLE
Check if stop_times exists in validators.check_trips

### DIFF
--- a/gtfstk/validators.py
+++ b/gtfstk/validators.py
@@ -1478,7 +1478,7 @@ def check_trips(
 
     # Check for trips with no stop times
     if include_warnings:
-        s = feed.stop_times["trip_id"]
+        s = feed.stop_times["trip_id"] if feed.stop_times is not None else []
         cond = ~f["trip_id"].isin(s)
         problems = check_table(
             problems, table, f, cond, "Trip has no stop times", "warning"

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -681,6 +681,11 @@ def test_check_trips():
     assert not check_trips(feed)
     assert check_trips(feed, include_warnings=True)
 
+    feed = sample.copy()
+    feed.stop_times = None
+    assert not check_trips(feed)
+    assert check_trips(feed, include_warnings=True)
+
 
 def test_validate():
     assert not validate(sample, as_df=False, include_warnings=False)


### PR DESCRIPTION
Added an extra condition which checks if feed.stop_times exists in order to avoid the invalid attribute error from feed.stop_times['trip_id']