### PR TITLE
Check if stop_times exists in validators.check_stops

### DIFF
--- a/gtfstk/validators.py
+++ b/gtfstk/validators.py
@@ -1224,7 +1224,10 @@ def check_stops(
 
     if include_warnings:
         # Check for stops of location type 0 or NaN without stop times
-        ids = feed.stop_times.stop_id.unique()
+        ids = []
+        if feed.stop_times is not None:
+            ids = feed.stop_times.stop_id.unique()
+
         cond = ~feed.stops.stop_id.isin(ids)
         if "location_type" in feed.stops.columns:
             cond &= f.location_type.isin([0, np.nan])

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -530,6 +530,11 @@ def test_check_stops():
     assert not check_stops(feed)
     assert check_stops(feed, include_warnings=True)
 
+    feed = sample.copy()
+    feed.stop_times = None
+    assert not check_stops(feed)
+    assert check_stops(feed, include_warnings=True)
+
 
 def test_check_stop_times():
     assert not check_stop_times(sample)


### PR DESCRIPTION
Added an extra condition which checks if feed.stop_times exists in order to avoid the invalid attribute error from feed.stop_times.stop_id.